### PR TITLE
Dmbirjuk/openssl signature validator

### DIFF
--- a/src/inc/internal/IXml.hpp
+++ b/src/inc/internal/IXml.hpp
@@ -201,6 +201,7 @@ namespace MSIX {
         static uint32_t Get(const std::string&)
         {
             static_assert(False<T>::value, "An appropriate specialization must be specified");
+            return 0;   // silence GCC warnings
         }
     };
 

--- a/src/inc/public/MSIXWindows.hpp
+++ b/src/inc/public/MSIXWindows.hpp
@@ -140,8 +140,8 @@
     typedef int BOOL;
     #endif
 
-    #ifndef _SIZE_T_DEFINED
-    #define _SIZE_T_DEFINED
+    #ifndef _WINSIZE_T_DEFINED
+    #define _WINSIZE_T_DEFINED
     typedef size_t SIZE_T;
     #endif
 


### PR DESCRIPTION
Two commits here:
1. Fix build issues under GCC:
    a. _SIZE_T_DEFINED under GCC means that `size_t` is defined, but not `SIZE_T`. We should use something more windows-specific here. It's safe, since non-windows toolchains don't define `SIZE_T` by themselves.
    b. Missing return from a function triggers a warning, even though this function never gets truly compiled. Probably an old GCC bug.
2. Add support for non-store Microsoft signatures for OpenSSL-based signature validator.
    a. Export a FULL TRUSTED cert chain from validation process. This chain shall contain both the root certificate (last in chain) AND the signing certificate (first in chain).
    b. Consider package origin as SignatureOrigin::Windows if and only if:
        - Chain is fully trusted.
        - Root certificate comes from Microsoft Root Certificate Authority
        - Signing certificate has "Code Signing" key usage.
    c. Rename `trustedChain` into `trustedStack`, because variable name is misleading: it's just a collection of trusted root certs, NOT a chain.
    d. Allow SignatureOrigin::Windows signatures when using `MSIX_VALIDATION_OPTION_FULL`